### PR TITLE
WIP: fix: determine log levels after registerCommands finished

### DIFF
--- a/packages/yargs/index.js
+++ b/packages/yargs/index.js
@@ -11,7 +11,7 @@ exports.run = (...argv) => {
   if (yargs.argv.production || yargs.argv.p) {
     process.env.NODE_ENV = 'production';
   }
-  const { registerCommands, logError } = bootstrap();
+  const { registerCommands, registerLogLevels, logError } = bootstrap();
 
   const onError = error => void logError(error) || process.exit(1);
   process.on('uncaughtException', onError);
@@ -28,6 +28,8 @@ exports.run = (...argv) => {
       .demandCommand(1, ''),
     chalk
   );
+
+  registerLogLevels(yargs.alias('l', 'log').argv);
 };
 
 if (require.main === module) {

--- a/packages/yargs/mixin.core.js
+++ b/packages/yargs/mixin.core.js
@@ -5,11 +5,13 @@ const { Mixin } = require('@untool/core');
 
 class YargsMixin extends Mixin {
   registerCommands(yargs, chalk) {
-    const levels = ['debug', 'info', 'warn', 'error', 'silent'];
-    const index = levels.indexOf(yargs.alias('l', 'log').argv.log);
-    this.levels = levels.slice(Math.max(index, 0), -1);
     this.chalk = chalk;
     return yargs;
+  }
+  registerLogLevels(argv) {
+    const levels = ['debug', 'info', 'warn', 'error', 'silent'];
+    const index = levels.indexOf(argv.log);
+    this.levels = levels.slice(Math.max(index, 0), -1);
   }
   logDebug(...args) {
     const { namespace } = this.config;
@@ -52,6 +54,7 @@ class YargsMixin extends Mixin {
 
 YargsMixin.strategies = {
   registerCommands: pipe,
+  registerLogLevels: override,
   logDebug: override,
   logInfo: override,
   logWarn: override,


### PR DESCRIPTION
because `yargs.argv` is a side-effectful getter that parses
`process.argv` - and after that happened we can't register other
commands anymore.