### PR TITLE
[RFC] React: allow to hook into template with head and body functions

### DIFF
--- a/packages/react/lib/template.js
+++ b/packages/react/lib/template.js
@@ -8,6 +8,7 @@ module.exports = data =>
   `<!DOCTYPE html>
 <html ${data.helmet.htmlAttributes.toString()}>
   <head>
+    ${data.prependHead().join('')}
     ${data.helmet.title.toString()}
     ${data.helmet.base.toString()}
     ${data.helmet.meta.toString()}
@@ -15,11 +16,15 @@ module.exports = data =>
     ${data.assetsByType.css.map(cssLink).join('')}
     ${data.helmet.style.toString()}
     ${data.helmet.script.toString()}
+    ${data.appendHead().join('')}
+    
   </head>
   <body ${data.helmet.bodyAttributes.toString()}>
+    ${data.prependBody().join('')}
     <div id="${data.mountpoint}">${data.markup}</div>
     ${data.helmet.noscript.toString()}
     ${data.globals.map(variable).join('')}
     ${data.assetsByType.js.map(jsLink).join('')}
+    ${data.appendBody().join('')}
   </body>
 </html>`.replace(/(^\s*[\r\n]| (?=>))/gm, '');

--- a/packages/react/mixin.server.js
+++ b/packages/react/mixin.server.js
@@ -3,7 +3,11 @@ const { renderToString } = require('react-dom/server');
 const { StaticRouter } = require('react-router');
 const { Helmet } = require('react-helmet');
 
-const { override, async: { compose, parallel, pipe } } = require('mixinable');
+const {
+  override,
+  sync: { sequence },
+  async: { compose, parallel, pipe },
+} = require('mixinable');
 
 const { Mixin } = require('@untool/core');
 
@@ -39,6 +43,7 @@ class ReactPlugin extends Mixin {
       globals: [],
     };
   }
+
   render(req, res, next) {
     Promise.resolve()
       .then(() => this.bootstrap(req, res))
@@ -67,10 +72,15 @@ class ReactPlugin extends Mixin {
       .catch(next);
   }
   renderToString(element, data) {
+    const markup = renderToString(element);
     return template({
       ...data,
-      markup: renderToString(element),
+      markup,
       helmet: Helmet.renderStatic(),
+      appendHead: this.appendHead,
+      prependHead: this.prependHead,
+      appendBody: this.appendBody,
+      prependBody: this.prependBody,
     });
   }
 }
@@ -80,6 +90,11 @@ ReactPlugin.strategies = {
   bootstrap: parallel,
   enhanceElement: compose,
   fetchData: pipe,
+
+  prependHead: sequence,
+  appendHead: sequence,
+  prependBody: sequence,
+  appendBody: sequence,
 };
 
 module.exports = ReactPlugin;


### PR DESCRIPTION
This PR is intended as a discussion starter.

Projects such as [styled-components](https://www.styled-components.com/docs/advanced#server-side-rendering) or [react-loadable](https://github.com/jamiebuilds/react-loadable#loadablecapture) (both links lead directly to their respective SSR docs) analyze the rendered app in order to gather information. styled-components finds the used styles on the page. react-loadable determines the components that have been loaded in the request.

However, currently besides overriding `render`, there seems not to be a way to alter the template data after `ReactDom.renderToString` has been called.

## Idea
Allow to add markup to head/body with hooks (`prependHead`, `appendHead`, `prependBody`, `appendBody`)  without having to override the entire template or render function.
Those hooks will be called *after* `ReactDom.renderToString` so they'd be able to access any data created by react-loadable, styled-components or similar packages.
