### PR TITLE
fix(react): fix data.globals always being overridden

### DIFF
--- a/packages/react/mixin.server.js
+++ b/packages/react/mixin.server.js
@@ -36,7 +36,7 @@ class ReactPlugin extends Mixin {
       ...data,
       mountpoint: this.config.namespace,
       assetsByType: this.assetsByType,
-      globals: [],
+      globals: data.globals || [],
       fragments: Object.keys(data.helmet).reduce(
         (result, key) => ({
           ...result,


### PR DESCRIPTION
Setting data.globals in `fetchData` had no effect, because it was always set
to an empty array in `enhanceData`.