### PR TITLE
fix(webpack): "rootDir" must point to a directory, not the package.json

### DIFF
--- a/packages/webpack/lib/utils/loader.js
+++ b/packages/webpack/lib/utils/loader.js
@@ -18,7 +18,7 @@ const getModule = (target, config) =>
   (target === 'server'
     ? [
         'var path = require("path");',
-        'var root = require("find-up").sync("package.json");',
+        'var root = path.dirname(require("find-up").sync("package.json"));',
         'var expand = path.join.bind(path, root);',
       ]
     : []


### PR DESCRIPTION
In the server mixins the "rootDir" config key was pointing to the
location of the `package.json` file - instead it should point to the
directory containing the `package.json` file.