### PR TITLE
RFC: add debug output for config / mixins

### DIFF
--- a/packages/core/lib/config.js
+++ b/packages/core/lib/config.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('untool:config');
 const { basename, dirname, join } = require('path');
 
 const {
@@ -168,8 +169,12 @@ exports.getConfig = () => {
   delete config.presets;
   delete config.env;
 
-  return {
+  const result = {
     ...substitutePlaceholders(config),
     mixins: resolveMixins(rootDir, config.mixins),
   };
+
+  debug(result);
+
+  return result;
 };

--- a/packages/core/lib/core.js
+++ b/packages/core/lib/core.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('untool:core');
 const define = require('mixinable');
 
 const { getConfig } = require('./config');
@@ -17,5 +18,8 @@ exports.bootstrap = function bootstrap(...args) {
       {}
     ),
   };
+
+  debug(mixins.map(({ name, strategies }) => ({ [name]: strategies })));
+
   return define(strategies)(...mixins)(config, ...args);
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,12 +22,14 @@
   "homepage": "https://github.com/untool/untool#readme",
   "dependencies": {
     "cosmiconfig": "^5.0.5",
+    "debug": "^3.1.0",
     "enhanced-resolve": "^4.0.0",
     "find-up": "^3.0.0",
     "flat": "^4.0.0",
     "is-plain-object": "^2.0.4",
     "lodash.mergewith": "^4.6.1",
-    "mixinable": "^3.0.0"
+    "mixinable": "^3.0.0",
+    "supports-color": "^5.4.0"
   },
   "engines": {
     "node": ">8.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6833,7 +6833,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^5.0.0, supports-color@^5.2.0, supports-color@^5.3.0:
+supports-color@^5.0.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:


### PR DESCRIPTION
This commit adds debug output (via the
[debug package](https://www.npmjs.com/package/debug)).

In order to see the debug output the app needs to be started with the
`DEBUG` environment variable set to `untool:*`.
`$ DEBUG=untool:* un start` will print all debug statements starting
with namespace `untool:`.

This commit introduces two debug namespaces:
- `untool:core`
- `untool:config`

Sample output:
![screenshot](https://user-images.githubusercontent.com/249542/41670929-f458f12a-74b5-11e8-8de6-fb22fd21dfeb.png)
