### PR TITLE
fix(core): take devDependencies into account when resolving presets

### DIFF
--- a/packages/core/lib/config.js
+++ b/packages/core/lib/config.js
@@ -93,20 +93,26 @@ const loadConfig = (context, config) => {
     : searchSync(context);
 };
 
-const loadSettings = (context, { dependencies }) => {
+const loadSettings = (context, { dependencies = {}, devDependencies = {} }) => {
   const result = loadConfig(context);
   const settings = {
     ...(result ? result.config : {}),
   };
   if (!settings.presets) {
-    settings.presets = Object.keys(dependencies).filter((key) => {
-      try {
-        return loadConfig(context, key);
-      } catch (error) {
-        if (!isResolveError(error)) throw error;
-        return null;
-      }
-    });
+    settings.presets = Object.keys(dependencies)
+      .concat(
+        process.env.NODE_ENV !== 'production'
+          ? Object.keys(devDependencies)
+          : []
+      )
+      .filter((key) => {
+        try {
+          return loadConfig(context, key);
+        } catch (error) {
+          if (!isResolveError(error)) throw error;
+          return null;
+        }
+      });
   }
   return settings;
 };


### PR DESCRIPTION
Imo devDependencies should also be used to resolve presets.

For example, we are currently building a development proxy that is only needed for development. https://github.com/xing/hops/pull/522

jest-preset could be(come) another example.

Otherwise, you would either have to install devDependencies as dependencies or specify the presets manually.