### PR TITLE
[RFC]: Enable possible support for tree-shaking untool/hops applications

### DIFF
--- a/packages/react/mixin.browser.js
+++ b/packages/react/mixin.browser.js
@@ -4,7 +4,7 @@
 
 const { createElement } = require('react');
 const { unmountComponentAtNode, hydrate, render } = require('react-dom');
-const { BrowserRouter } = require('react-router-dom');
+const { default: BrowserRouter } = require('react-router-dom/BrowserRouter');
 
 const {
   async: { compose, parallel, pipe },

--- a/packages/react/mixin.server.js
+++ b/packages/react/mixin.server.js
@@ -2,7 +2,7 @@
 
 const { createElement } = require('react');
 const { renderToString } = require('react-dom/server');
-const { StaticRouter } = require('react-router-dom');
+const { default: StaticRouter } = require('react-router-dom/StaticRouter');
 const { Helmet } = require('react-helmet');
 const clone = require('clone');
 

--- a/packages/webpack/lib/middleware/render.js
+++ b/packages/webpack/lib/middleware/render.js
@@ -29,7 +29,8 @@ module.exports = function createRenderMiddleware(webpackConfig) {
         fs.readFile(filePath, 'utf8', (readError, fileContents) => {
           if (readError) return reject(readError);
           try {
-            resolve(requireFromString(fileContents, filePath));
+            const middleware = requireFromString(fileContents, filePath);
+            resolve(middleware.default);
           } catch (moduleError) {
             reject(moduleError);
           }

--- a/packages/webpack/lib/shims/browser.js
+++ b/packages/webpack/lib/shims/browser.js
@@ -1,19 +1,13 @@
-'use strict';
-
-const { getConfigAndMixins } = require('./loader');
+import { getConfigAndMixins } from './loader';
+import entryPoint from '@untool/entrypoint';
 
 (function render() {
-  let entryPoint = require('@untool/entrypoint');
-  if (typeof entryPoint.default === 'function') {
-    entryPoint = entryPoint.default;
-  }
-
   const { config, mixins } = getConfigAndMixins();
 
   entryPoint(config, mixins)();
 
   if (module.hot) {
-    module.hot.accept(require.resolve('@untool/entrypoint'), function() {
+    module.hot.accept('@untool/entrypoint', function() {
       setTimeout(render);
     });
   }

--- a/packages/webpack/lib/shims/node.js
+++ b/packages/webpack/lib/shims/node.js
@@ -1,14 +1,7 @@
-'use strict';
-
-require('source-map-support/register');
-
-const { getConfigAndMixins } = require('./loader');
-
-let entryPoint = require('@untool/entrypoint');
-if (typeof entryPoint.default === 'function') {
-  entryPoint = entryPoint.default;
-}
+import 'source-map-support/register';
+import { getConfigAndMixins } from './loader';
+import entryPoint from '@untool/entrypoint';
 
 const { config, mixins } = getConfigAndMixins();
 
-module.exports = entryPoint(config, mixins);
+export default entryPoint(config, mixins);

--- a/packages/webpack/mixin.core.js
+++ b/packages/webpack/mixin.core.js
@@ -24,7 +24,7 @@ class WebpackMixin extends Mixin {
     const statsFilePath = join(serverDir, statsFile);
     this.stats.resolve(exists(statsFilePath) ? require(statsFilePath) : {});
     if (exists(serverFilePath)) {
-      return require(serverFilePath);
+      return require(serverFilePath).default;
     } else {
       return (req, res, next) => next();
     }


### PR DESCRIPTION
In order to use tree-shaking features, the entry point needs to be in
ESM format.

This PR rewrites the browser entry point to use ESM and also uses deep
imports to react-router-dom in order to not bundle the whole of
react-router.