### PR TITLE
fix(webpack): emit stats file only for parent compilation

### DIFF
--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -52,6 +52,9 @@ exports.StatsPlugin = class StatsPlugin {
     this.apply = (compiler) => {
       compiler.hooks.compilation.tap('StatsPlugin', (compilation) => {
         compilation.hooks.additionalAssets.tap('StatsPlugin', () => {
+          if (compilation.compiler !== compiler) {
+            return;
+          }
           try {
             resolvable.resolve({
               ...compilation.getStats().toJson({ source: false }),


### PR DESCRIPTION
The compilation hook "additionalAssets" will be called multiple times
if there are "childCompiler"s present.

In order to prevent this behavior and only emit the "statsFile" for the
compilation object of the parent compiler, we need to filter out
compilations of other compilers which might be present.