### PR TITLE
fix(core): allow calling getConfig without arguments

### DIFF
--- a/packages/core/lib/config.js
+++ b/packages/core/lib/config.js
@@ -21,7 +21,7 @@ exports.getConfig = ({
   untoolNamespace: namespace = defaultNamespace,
   untoolMixinTypes: mixinTypes = defaultMixinTypes,
   ...overrides
-}) => {
+} = {}) => {
   const pkgFile = findUp('package.json');
   const pkgData = require(pkgFile);
   const rootDir = dirname(pkgFile);


### PR DESCRIPTION
Otherwise it breaks with `TypeError: Cannot destructure property `configNamespace` of 'undefined' or 'null'.`