### PR TITLE
fix(webpack): use target as name for getBuildConfig

### DIFF
--- a/packages/webpack/lib/configs/build.js
+++ b/packages/webpack/lib/configs/build.js
@@ -74,7 +74,6 @@ module.exports = function getConfig(config) {
       fileLoaderConfig,
       allLoaderConfigs,
     },
-    name: 'build',
     mode: isProduction ? 'production' : 'development',
     bail: isProduction,
     context: config.rootDir,

--- a/packages/webpack/lib/configs/develop.js
+++ b/packages/webpack/lib/configs/develop.js
@@ -72,7 +72,6 @@ module.exports = function getConfig(config) {
       fileLoaderConfig,
       allLoaderConfigs,
     },
-    name: 'develop',
     mode: 'development',
     context: config.rootDir,
     entry: [

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -74,7 +74,6 @@ module.exports = function getConfig(config) {
       fileLoaderConfig,
       allLoaderConfigs,
     },
-    name: 'node',
     target: 'node',
     mode: isProduction ? 'production' : 'development',
     bail: isProduction,

--- a/packages/webpack/mixins/config/mixin.core.js
+++ b/packages/webpack/mixins/config/mixin.core.js
@@ -40,6 +40,7 @@ class WebpackConfigMixin extends Mixin {
     }
   }
   configureBuild(webpackConfig, loaderConfigs, target) {
+    webpackConfig.name = target;
     const { module } = webpackConfig;
     const configLoaderConfig = {
       test: require.resolve('@untool/core/lib/config'),


### PR DESCRIPTION
This change allows us to call `this.getBuildConfig('my-build', 'node')`
which will return a webpack config based on the node config and will
call `configureBuild(webpackConfig, loaderConfigs, 'my-build')` with
`target` set to `my-build`, so that the custom webpack config can be
configured via `configureBuild` too.