### PR TITLE
fix(react): avoid special chars causing issues with React mountpoint

### DIFF
--- a/packages/react/mixins/mixin.browser.js
+++ b/packages/react/mixins/mixin.browser.js
@@ -26,7 +26,7 @@ class ReactMixin extends Mixin {
   render() {
     const { name } = this.config;
     const attribute = `data-${name}`;
-    const mountpoint = document.querySelector(`#${name}`);
+    const mountpoint = document.getElementById(name);
     const isMounted = mountpoint.hasAttribute(attribute);
     if (isMounted) {
       unmountComponentAtNode(mountpoint);


### PR DESCRIPTION
HTML5 is pretty forgiving in what it allows to be in an id
However, not everything can be queried using CSS selectors

`document.querySelector(@package/myName)` will produce an error
`document.querySelector(#package.myName)` will not query for `[id="package.myName"]` but for an element with id `package` and class `myName`