### PR TITLE
Remove non-hook mixin methods from `@untool/react`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -163,7 +163,9 @@ MyMixin.strategies = {
 export default MyMixin;
 ```
 
-If inheriting from `Mixin`, all methods of your mixin are automatically bound to the repective instance, so you do not have to call `this.method.bind(this)` yourself even if you use them in asynchronous contexts.
+If inheriting from `Mixin`, all mixinable methods of your mixin are automatically bound to the respective instance, so you do not have to call `method.bind()` yourself even if you use them in asynchronous contexts.
+
+While it is technically possible to define non-mixin utility methods on your mixin, doing so is strongly discouraged. If you have to, however, it is recommended to prefix such methods' names with an underscore (`_`) to denote them as private.
 
 Note that you can call all defined mixinable methods directly on your mixin instance.
 

--- a/packages/react/lib/render.js
+++ b/packages/react/lib/render.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { extname } = require('path');
+
+const { renderToString } = require('react-dom/server');
+const { Helmet } = require('react-helmet');
+
+function determineAssets(modules, stats) {
+  const { entryFiles, vendorFiles, moduleFileMap } = stats;
+  const moduleFiles = modules.reduce(
+    (result, module) => [...result, ...moduleFileMap[module]],
+    []
+  );
+  return [
+    ...vendorFiles.sort((a, b) => b.localeCompare(a)),
+    ...moduleFiles.sort((a, b) => b.localeCompare(a)),
+    ...entryFiles.sort((a, b) => b.localeCompare(a)),
+  ]
+    .filter(
+      (asset, index, self) =>
+        self.indexOf(asset) === index &&
+        /\.(css|js)$/.test(asset) &&
+        !/\.hot-update\./.test(asset)
+    )
+    .reduce(
+      (result, asset) => {
+        const extension = extname(asset).substring(1);
+        result[extension].push(asset);
+        return result;
+      },
+      { css: [], js: [] }
+    );
+}
+
+module.exports = function render(element, fetchedData, config, modules, stats) {
+  const markup = renderToString(element);
+  const helmet = Helmet.renderStatic();
+  const fragments = Object.entries(helmet).reduce(
+    (result, [key, value]) => ({ ...result, [key]: value.toString() }),
+    { headPrefix: '', headSuffix: '' }
+  );
+  const assets = determineAssets(modules, stats);
+  const { name: mountpoint, _env } = config;
+  const globals = { _env };
+  return { fetchedData, markup, fragments, assets, mountpoint, globals };
+};

--- a/packages/react/mixins/mixin.core.js
+++ b/packages/react/mixins/mixin.core.js
@@ -14,9 +14,6 @@ module.exports = class ReactMixin extends Mixin {
       /node_modules\/react/
     );
 
-    // jsLoaderConfig.options.presets
-    //   .find((p) => Array.isArray(p) && p[0].includes('@babel/preset-env'))[1]
-    //   .include.push('es6.symbol');
     jsLoaderConfig.options.presets.push(require.resolve('@babel/preset-react'));
 
     if (target !== 'develop' && process.env.NODE_ENV === 'production') {

--- a/packages/react/mixins/mixin.server.js
+++ b/packages/react/mixins/mixin.server.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const { extname } = require('path');
 const { parse } = require('url');
 
 const { createElement } = require('react');
-const { renderToString } = require('react-dom/server');
 const { default: StaticRouter } = require('react-router-dom/es/StaticRouter');
-const { Helmet } = require('react-helmet');
 
 const {
   override,
@@ -15,6 +12,7 @@ const {
 
 const { Mixin } = require('@untool/core');
 
+const render = require('../lib/render');
 const template = require('../lib/template');
 
 class ReactMixin extends Mixin {
@@ -25,42 +23,6 @@ class ReactMixin extends Mixin {
     const modules = (this.modules = []);
     const context = (this.context = { modules });
     this.options = { ...(options && options.router), basename, context };
-  }
-  determineAssets() {
-    const { entryFiles, vendorFiles, moduleFileMap } = this.stats;
-    const moduleFiles = this.modules.reduce(
-      (result, module) => [...result, ...moduleFileMap[module]],
-      []
-    );
-    return [
-      ...vendorFiles.sort((a, b) => b.localeCompare(a)),
-      ...moduleFiles.sort((a, b) => b.localeCompare(a)),
-      ...entryFiles.sort((a, b) => b.localeCompare(a)),
-    ]
-      .filter(
-        (asset, index, self) =>
-          self.indexOf(asset) === index &&
-          /\.(css|js)$/.test(asset) &&
-          !/\.hot-update\./.test(asset)
-      )
-      .reduce(
-        (result, asset) => {
-          const extension = extname(asset).substring(1);
-          result[extension].push(asset);
-          return result;
-        },
-        { css: [], js: [] }
-      );
-  }
-  getInitialTemplateData({ helmet, ...data }) {
-    const { name: mountpoint, _env } = this.config;
-    const assets = this.determineAssets();
-    const fragments = Object.entries(helmet).reduce(
-      (result, [key, value]) => ({ ...result, [key]: value.toString() }),
-      { headPrefix: '', headSuffix: '' }
-    );
-    const globals = { _env };
-    return { ...data, mountpoint, assets, fragments, globals };
   }
   bootstrap(req, res) {
     const { pathname, search } = parse(req.url);
@@ -75,14 +37,11 @@ class ReactMixin extends Mixin {
       .then(() => this.bootstrap(req, res))
       .then(() => this.enhanceElement(this.element))
       .then((element) =>
-        this.fetchData({}, element).then((data) => ({ element, data }))
+        this.fetchData({}, element).then((data) =>
+          render(element, data, this.config, this.modules, this.stats)
+        )
       )
-      .then(({ element, data: fetchedData }) => {
-        const initialData = this.getInitialTemplateData({
-          markup: renderToString(element),
-          helmet: Helmet.renderStatic(),
-          fetchedData,
-        });
+      .then((initialData) => {
         if (this.context.miss) {
           next();
         } else if (this.context.url) {


### PR DESCRIPTION
We decided to strongly discourage adding non-hook methods to mixins as doing so may result in namespace clashes. In this PR, I added appropriate documentation and refactored `@untool/react`'s server mixin to make sure we ourselves adhere to this new best practice.