### PR TITLE
perf(webpack): only re-evaluate config when overrides exist

### DIFF
--- a/packages/webpack/lib/utils/loader.js
+++ b/packages/webpack/lib/utils/loader.js
@@ -32,7 +32,8 @@ module.exports = function configLoader() {
     `const override = (...args) => merge(${getConfig(type, config)}, ...args);`,
     'const functions = [override, placeholdify, environmentalize];',
     'const getConfig = [].reduce.bind(functions, (res, fn) => fn(res));',
-    'exports.getConfig = (overrides = {}) => getConfig(overrides);',
+    'const config = getConfig({})',
+    'exports.getConfig = (overrides = {}) => !Object.keys(overrides).length ? config : getConfig(overrides);',
     `exports.getMixins = () => ${getMixins(type, config)};`,
   ].join('\n');
 };


### PR DESCRIPTION
We noticed that running "placeholdify" etc on the config is extremely
costly and at the moment we were executing it on every request.

With this change we will only re-evaluate the config whenever
"overrides" are actually used (most of the times it is just an empty
object).

We measured reqs/sec and on my machine (with hops-template-react), we
got on average:
- before: ~1700 reqs/sec
- after: ~2100 reqs/sec

Co-authored-by: Robin Drexler <drexler.robin@gmail.com>