### PR TITLE
[WIP][RFC] perf(express): use node cluster module to speed up request handling

### DIFF
--- a/packages/express/lib/getPort.js
+++ b/packages/express/lib/getPort.js
@@ -1,0 +1,7 @@
+const portfinder = require('portfinder');
+
+module.exports = function getPort(port) {
+  if (port) return Promise.resolve(port);
+  portfinder.basePort = 8080;
+  return portfinder.getPortPromise();
+};

--- a/packages/express/lib/run.js
+++ b/packages/express/lib/run.js
@@ -5,8 +5,7 @@ const { join } = require('path');
 
 const { createServer: createHTTPServer } = require('http');
 const { createServer: createHTTPSServer } = require('https');
-
-const portfinder = require('portfinder');
+const getPort = require('./getPort');
 
 const createServer = (app, https) =>
   https
@@ -22,12 +21,6 @@ const createServer = (app, https) =>
         app
       )
     : createHTTPServer(app);
-
-const getPort = (port) => {
-  if (port) return Promise.resolve(port);
-  portfinder.basePort = 8080;
-  return portfinder.getPortPromise();
-};
 
 module.exports = (app, { config, inspectServer, handleError }) => {
   const { host, port, https } = config;


### PR DESCRIPTION
Just toyed with clusters a bit, but thought I'd still share.

On my old-ish early 2015 macbook with 4 core i5, I could go from ~2k requests/second to about 3.2k requests/second.

For some reason using `worker.send` right after forking did not work. Same for using `cluster.on('online')` Only sending a message from the worker first seemed to resolve the issue. 

So if anybody can help me with that I'm doing wrong (regardless of if we ever want something like that in untool) I'd be really grateful. :) Maybe it has something todo with waiting until the `getPort` promise resolves? 

I'm not sure how often people actually use multi-core machines in production, though.