### PR TITLE
fix(react): ensure Symbol-polyfill is present in time

### DIFF
--- a/packages/react/mixins/mixin.core.js
+++ b/packages/react/mixins/mixin.core.js
@@ -8,6 +8,10 @@ module.exports = class ReactMixin extends Mixin {
     fileLoaderConfig.exclude.push(/\.jsx$/);
     jsLoaderConfig.test.push(/\.jsx$/);
 
+    webpackConfig.entry = [require.resolve('core-js/es6/symbol')].concat(
+      webpackConfig.entry
+    );
+
     jsLoaderConfig.exclude.push(
       /node_modules\/react-helmet/,
       /node_modules\/react-dom/,


### PR DESCRIPTION
...which is a delicate issue since babel-preset-env does not parse React files for usages.

@dmbch PTAL