### PR TITLE
Use `process.env.NODE_ENV` wherever possible

### DIFF
--- a/packages/webpack/mixins/start/mixin.core.js
+++ b/packages/webpack/mixins/start/mixin.core.js
@@ -24,7 +24,7 @@ class WebpackStartMixin extends Mixin {
           },
         },
         handler: (argv) => {
-          if (argv.production) {
+          if (process.env.NODE_ENV === 'production') {
             Promise.resolve(argv.clean && this.clean())
               .then(this.build)
               .then(this.runServer.bind(this, 'serve'))

--- a/packages/yargs/mixins/log/mixin.core.js
+++ b/packages/yargs/mixins/log/mixin.core.js
@@ -20,7 +20,7 @@ module.exports = class CLIMixin extends Mixin {
     const { quiet } = this.options;
     if (!quiet) {
       const { name } = this.config;
-      const mode = argv.production ? 'production' : 'development';
+      const mode = process.env.NODE_ENV || 'development';
       console.log(`[${name}] started in ${mode} mode`);
     }
   }


### PR DESCRIPTION
Closes #223 