### PR TITLE
refactor(webpack): use `compiler.isChild()`

### DIFF
--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -52,7 +52,7 @@ exports.StatsPlugin = class StatsPlugin {
     this.apply = (compiler) => {
       compiler.hooks.compilation.tap('StatsPlugin', (compilation) => {
         compilation.hooks.additionalAssets.tap('StatsPlugin', () => {
-          if (compilation.compiler !== compiler) {
+          if (compilation.compiler.isChild()) {
             return;
           }
           try {


### PR DESCRIPTION
Please see [my comment](https://github.com/untool/untool/pull/236/files/5dc4a09451f93f029f303e11967c0b1a41ca8fbf#r244835805) in #236.