### PR TITLE
Fix template

### DIFF
--- a/packages/react/lib/template.js
+++ b/packages/react/lib/template.js
@@ -2,18 +2,24 @@
 
 const esc = require('serialize-javascript');
 
-const renderCSS = ({ css }) =>
+const renderCSS = (css) =>
   css.map((asset) => `<link rel="stylesheet" href="/${asset}" />`).join('');
 
-const renderJS = ({ js }) =>
+const renderJS = (js) =>
   js.map((asset) => `<script src="/${asset}"></script>`).join('');
 
-const renderGlobals = (globals = {}) => {
+const renderGlobals = (globals) => {
   const entries = Object.entries(globals).map(([k, v]) => `${k}=${esc(v)}`);
   return entries.length ? `<script>var ${entries.join(',')};</script>` : '';
 };
 
-module.exports = ({ fragments = {}, assets, mountpoint, markup, globals }) =>
+module.exports = ({
+  markup,
+  mountpoint,
+  fragments = {},
+  globals = {},
+  assets: { css = [], js = [] } = {},
+}) =>
   `<!DOCTYPE html>
 <html ${fragments.htmlAttributes || ''}>
   <head>
@@ -22,15 +28,15 @@ module.exports = ({ fragments = {}, assets, mountpoint, markup, globals }) =>
     ${fragments.base || ''}
     ${fragments.meta || ''}
     ${fragments.link || ''}
-    ${renderCSS(assets)}
+    ${renderCSS(css)}
     ${fragments.style || ''}
     ${fragments.script || ''}
     ${fragments.headSuffix || ''}
   </head>
   <body ${fragments.bodyAttributes || ''}>
-    <div id="${mountpoint}">${markup || ''}</div>
+    <div id="${mountpoint || ''}">${markup || ''}</div>
     ${fragments.noscript || ''}
     ${renderGlobals(globals)}
-    ${renderJS(assets)}
+    ${renderJS(js)}
   </body>
 </html>`;

--- a/packages/react/lib/template.js
+++ b/packages/react/lib/template.js
@@ -8,28 +8,28 @@ const renderCSS = ({ css }) =>
 const renderJS = ({ js }) =>
   js.map((asset) => `<script src="/${asset}"></script>`).join('');
 
-const renderGlobals = (globals) => {
+const renderGlobals = (globals = {}) => {
   const entries = Object.entries(globals).map(([k, v]) => `${k}=${esc(v)}`);
   return entries.length ? `<script>var ${entries.join(',')};</script>` : '';
 };
 
-module.exports = ({ fragments, assets, mountpoint, markup, globals }) =>
+module.exports = ({ fragments = {}, assets, mountpoint, markup, globals }) =>
   `<!DOCTYPE html>
-<html ${fragments.htmlAttributes}>
+<html ${fragments.htmlAttributes || ''}>
   <head>
-    ${fragments.headPrefix}
-    ${fragments.title}
-    ${fragments.base}
-    ${fragments.meta}
-    ${fragments.link}
+    ${fragments.headPrefix || ''}
+    ${fragments.title || ''}
+    ${fragments.base || ''}
+    ${fragments.meta || ''}
+    ${fragments.link || ''}
     ${renderCSS(assets)}
-    ${fragments.style}
-    ${fragments.script}
-    ${fragments.headSuffix}
+    ${fragments.style || ''}
+    ${fragments.script || ''}
+    ${fragments.headSuffix || ''}
   </head>
-  <body ${fragments.bodyAttributes}>
-    <div id="${mountpoint}">${markup}</div>
-    ${fragments.noscript}
+  <body ${fragments.bodyAttributes || ''}>
+    <div id="${mountpoint}">${markup || ''}</div>
+    ${fragments.noscript || ''}
     ${renderGlobals(globals)}
     ${renderJS(assets)}
   </body>


### PR DESCRIPTION
@ZauberNerd:
> In case `fragments` is not defined or an empty object we should ensure that we don't render `undefined` in the template.
> This change adds `|| ''` and sets a default value of an empty object for `fragments`, so we will always render strings only.