### PR TITLE
fix(react): do not error when importComponent module not found

### DIFF
--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -13,20 +13,16 @@ const analyzeCompilation = ({ chunks, chunkGroups }) => {
     ],
     []
   );
-  const chunksByModule = chunks
-    .filter(
-      (chunk) => !entryChunks.includes(chunk) && !vendorChunks.includes(chunk)
-    )
-    .reduce(
-      (result, chunk) =>
-        Array.from(chunk.modulesIterable).reduce((result, module) => {
-          const { chunks } = chunkGroups.find(({ chunks }) =>
-            chunks.includes(chunk)
-          );
-          return [...result, [module.id, chunks]];
-        }, result),
-      []
-    );
+  const chunksByModule = chunks.reduce(
+    (result, chunk) =>
+      Array.from(chunk.modulesIterable).reduce((result, module) => {
+        const { chunks } = chunkGroups.find(({ chunks }) =>
+          chunks.includes(chunk)
+        );
+        return [...result, [module.id, chunks]];
+      }, result),
+    []
+  );
   return { entryChunks, vendorChunks, chunksByModule };
 };
 


### PR DESCRIPTION
When you `import` a component (or import a file that exports said component, even if you do not directly use that export), that you also import via `importComponent`, that component will end up in an entry or vendor bundle and thus not be available in the moduleFileMap.
Which causes the following error, when a page is loaded:

```
TypeError: moduleFileMap[module] is not iterable
```

You can reproduce this by going to `master` branch and placing:

```js
import { About as a } from './components/about';
```
in https://github.com/untool/untool/blob/master/tests/fixtures/untest/index.js#L6

This PR fixes the error by ignoring those modules.
I've also added a warning in dev, because this is a situation a user certainly does not want.
Maybe we even want to throw an actual error and don't let users do something like that? What do you think @dmbch ?

Btw: `header-max-length` is an utterly annoying linting rule. :D 