### PR TITLE
feat(core): make mixin types configurable

### DIFF
--- a/packages/core/lib/config.js
+++ b/packages/core/lib/config.js
@@ -1,6 +1,4 @@
 'use strict';
-// This file is usually not being used at runtime, but only at buildtime.
-// @untool/webpack is taking care of providing runtime configuration.
 
 const { basename, dirname, join } = require('path');
 
@@ -20,15 +18,24 @@ exports.getConfig = ({ untoolNamespace = 'untool', ...overrides } = {}) => {
 
   loadEnv({ path: join(rootDir, '.env') });
 
-  const { name = basename(rootDir), version = '0.0.0' } = pkgData;
-
-  const defaults = { rootDir, name, version, mixins: [] };
+  const defaults = {
+    rootDir,
+    name: pkgData.name || basename(rootDir),
+    version: pkgData.version || '0.0.0',
+    mixins: [],
+    mixinTypes: {
+      core: {
+        mainFiles: ['mixin.core', 'mixin'],
+        mainFields: ['mixin:core', 'mixin'],
+      },
+    },
+  };
   const settings = loadConfig(untoolNamespace, pkgData, rootDir);
 
-  const { mixins, ...raw } = merge(defaults, settings, overrides);
+  const { mixins, mixinTypes, ...raw } = merge(defaults, settings, overrides);
   const config = {
     ...environmentalize(placeholdify(raw)),
-    _mixins: resolveMixins(rootDir, mixins),
+    _mixins: resolveMixins(rootDir, mixinTypes, mixins),
   };
   debug(config);
   return config;

--- a/packages/core/lib/resolver.js
+++ b/packages/core/lib/resolver.js
@@ -7,37 +7,20 @@ const {
   create: { sync: createResolver },
 } = require('enhanced-resolve');
 
-const resolvePreset = createResolver({
+exports.resolve = resolve;
+
+exports.resolvePreset = createResolver({
   mainFiles: ['preset'],
   mainFields: ['preset'],
 });
 
-const resolveCoreMixin = createResolver({
-  mainFiles: ['mixin.core', 'mixin'],
-  mainFields: ['mixin:core', 'mixin'],
-});
-
-const resolveBrowserMixin = createResolver({
-  mainFiles: ['mixin.browser', 'mixin.runtime', 'mixin'],
-  mainFields: ['mixin:browser', 'mixin:runtime', 'mixin'],
-});
-
-const resolveServerMixin = createResolver({
-  mainFiles: ['mixin.server', 'mixin.runtime', 'mixin'],
-  mainFields: ['mixin:server', 'mixin:runtime', 'mixin'],
-});
-
-exports.resolve = resolve;
-
-exports.resolvePreset = resolvePreset;
-
-exports.resolveMixins = (context, mixins) => {
-  const resolvers = {
-    core: resolveCoreMixin,
-    browser: resolveBrowserMixin,
-    server: resolveServerMixin,
-  };
-  const result = { core: [], browser: [], server: [] };
+exports.resolveMixins = (context, types, mixins) => {
+  const result = {};
+  const resolvers = {};
+  Object.entries(types).forEach(([type, config]) => {
+    resolvers[type] = createResolver(config);
+    result[type] = [];
+  });
   return mixins.reduce((result, mixin) => {
     const found = Object.entries(resolvers).reduce((found, [key, resolve]) => {
       try {

--- a/packages/webpack/preset.js
+++ b/packages/webpack/preset.js
@@ -20,4 +20,14 @@ module.exports = {
     join(__dirname, 'mixins', 'start'),
     join(__dirname, 'mixins', 'stats'),
   ],
+  mixinTypes: {
+    browser: {
+      mainFiles: ['mixin.browser', 'mixin.runtime', 'mixin'],
+      mainFields: ['mixin:browser', 'mixin:runtime', 'mixin'],
+    },
+    server: {
+      mainFiles: ['mixin.server', 'mixin.runtime', 'mixin'],
+      mainFields: ['mixin:server', 'mixin:runtime', 'mixin'],
+    },
+  },
 };


### PR DESCRIPTION
Architecturally, this change makes `@untool/core` more extensible and prevents it from knowing anything about the browser/server distinction implemented using webpack.

Practically, this allows users to introduce custom mixin types (for example to implement extensible service worker presets) and thus build more advanced extensions.