### PR TITLE
fix(express): keep length property of middleware handlers

### DIFF
--- a/packages/express/lib/serve.js
+++ b/packages/express/lib/serve.js
@@ -40,9 +40,6 @@ module.exports = (mode, { configureServer }) => {
         container.use(
           ...middlewares.map((middleware) => {
             const fn = domain.bind(middleware);
-            // Keep the information of how many arguments the bound
-            // function takes for Express to know whether it's
-            // a router- or an error-handler.
             Object.defineProperty(fn, 'length', { value: middleware.length });
             return fn;
           })

--- a/packages/express/lib/serve.js
+++ b/packages/express/lib/serve.js
@@ -38,7 +38,14 @@ module.exports = (mode, { configureServer }) => {
       } else {
         const middlewares = [].concat(middleware);
         container.use(
-          ...middlewares.map((middleware) => domain.bind(middleware))
+          ...middlewares.map((middleware) => {
+            const fn = domain.bind(middleware);
+            // Keep the information of how many arguments the bound
+            // function takes for Express to know whether it's
+            // a router- or an error-handler.
+            Object.defineProperty(fn, 'length', { value: middleware.length });
+            return fn;
+          })
         );
       }
     });


### PR DESCRIPTION
This is relevant in the `final` phase middleware handlers, that are assigned to the Express app itself and might handle errors. Those error handlers are detected by Express by checking the amount of parameters the function takes. This information is lost, when the middleware is bound to the `domain`.