### PR TITLE
feat(react): allow import load function in importComponent

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,7 +53,7 @@ export default () => <Status code={404} />;
 
 ### `<Header name value />`
 
-With this component, you can declaratively set arbitrary HTTP headers from your React application.
+With this component, you can declaratively set arbitrary HTTP headers from your React application. On the client side, it is effectively a no-op.
 
 ```javascript
 import { Header } from '@untool/react';
@@ -61,17 +61,29 @@ import { Header } from '@untool/react';
 export default () => <Header name="X-Foo" value="Bar" />;
 ```
 
-### `importComponent(module, [exportName])`
+### `importComponent(module|moduleLoader, [exportName|exportResolver])`
 
 Using the `importComponent` helper, you can asynchronously require components into your application to help you reduce asset sizes. It works similarly to [`react-loadable`](https://github.com/jamiebuilds/react-loadable), but is deeply integrated with `untool`.
 
 ```javascript
 import { importComponent } from '@untool/react';
 
-const Home = importComponent('./home');
+const Home = importComponent('./home', 'Home');
 
 export default () => <Home />;
 ```
+
+Additionally, `importComponent` supports an alternative syntax that helps with editor and type checker integration since it does not rely on plain strings. The snippet below is functionally equivalent to the one above:
+
+```javascript
+import { importComponent } from '@untool/react';
+
+const Home = importComponent(() => import('./home'), ({ Home }) => Home);
+
+export default () => <Home />;
+```
+
+If you do no specify an `exportName` or `exportResolver`, `importComponent` will fall back to the imported modules `default` export.
 
 `importComponent` itself returns a React component supporting some props that enable you to control module loading and (placeholder) rendering.
 

--- a/packages/react/lib/runtime.js
+++ b/packages/react/lib/runtime.js
@@ -62,6 +62,7 @@ Header.propTypes = {
 exports.Header = withRouter(Header);
 
 exports.importComponent = ({ load, moduleId }, name = 'default') => {
+  const resolve = typeof name === 'function' ? name : (module) => module[name];
   class Importer extends Component {
     constructor({ staticContext }) {
       super();
@@ -69,7 +70,7 @@ exports.importComponent = ({ load, moduleId }, name = 'default') => {
         staticContext.modules.push(moduleId);
       }
       if (staticContext || __webpack_modules__[moduleId]) {
-        this.state = { Component: __webpack_require__(moduleId)[name] };
+        this.state = { Component: resolve(__webpack_require__(moduleId)) };
       } else {
         this.state = { loading: true };
       }
@@ -82,7 +83,7 @@ exports.importComponent = ({ load, moduleId }, name = 'default') => {
         Promise.resolve()
           .then(() => (loader ? loader(load) : load()))
           .then(
-            ({ [name]: Component }) => this.setState({ ...state, Component }),
+            (module) => this.setState({ ...state, Component: resolve(module) }),
             (error) => this.setState({ ...state, error })
           );
       }

--- a/tests/fixtures/untest/index.js
+++ b/tests/fixtures/untest/index.js
@@ -5,7 +5,10 @@ import { Switch, Route, Link } from 'react-router-dom/es';
 import { Miss, render, importComponent } from 'untool';
 
 const Home = importComponent('./components/home');
-const About = importComponent('./components/about', 'About');
+const About = importComponent(
+  () => import('./components/about'),
+  ({ About }) => About
+);
 
 const preload = ({ Component, error, loading, ...props }) => {
   if (loading) return <p>Loading...</p>;


### PR DESCRIPTION
https://astexplorer.net/#/gist/8aa47f0a6619cf54e99bdf60055bf7d0/b4e7efb45ce31269459f1ae67ed9b50d0e812802

In addition to

```js
importComponent('./foo')
```

also allow 

```js
importComponent(() => import('./foo'))
```

This will allow editors to resolve the imported component. In its current form, for editors it's just a string that they can't follow.