### PR TITLE
Detect duplicate preset installs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "cosmiconfig": "^5.0.5",
     "debug": "^4.0.0",
     "dotenv": "^6.0.0",
+    "duplitect": "^1.0.3",
     "enhanced-resolve": "^4.0.0",
     "escape-string-regexp": "^1.0.5",
     "find-up": "^3.0.0",
@@ -31,5 +32,8 @@
   },
   "engines": {
     "node": ">8.6.0"
+  },
+  "scripts": {
+    "postinstall": "duplitect @untool/core"
   }
 }

--- a/packages/dist/package.json
+++ b/packages/dist/package.json
@@ -6,9 +6,6 @@
   "bin": {
     "un": "lib/cli.js"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\""
-  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/untool/untool.git"
@@ -28,9 +25,13 @@
     "@untool/react": "^1.1.0",
     "@untool/webpack": "^1.1.0",
     "@untool/yargs": "^1.1.0",
+    "duplitect": "^1.0.3",
     "mixinable": "^4.0.0"
   },
   "engines": {
     "node": ">8.6.0"
+  },
+  "scripts": {
+    "postinstall": "duplitect untool @untool/*"
   }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -20,6 +20,7 @@
     "@untool/yargs": "^1.1.0",
     "debug": "^4.0.0",
     "directory-index": "^0.1.0",
+    "duplitect": "^1.0.3",
     "express": "^4.16.2",
     "helmet": "^3.12.1",
     "is-plain-object": "^2.0.4",
@@ -32,5 +33,8 @@
   },
   "engines": {
     "node": ">8.6.0"
+  },
+  "scripts": {
+    "postinstall": "duplitect @untool/express"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,6 +23,7 @@
     "@untool/core": "^1.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.19",
     "clone": "^2.1.2",
+    "duplitect": "^1.0.3",
     "is-plain-object": "^2.0.4",
     "mixinable": "^4.0.0",
     "prop-types": "^15.7.2",
@@ -36,5 +37,8 @@
   },
   "engines": {
     "node": ">8.6.0"
+  },
+  "scripts": {
+    "postinstall": "duplitect @untool/react"
   }
 }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-dynamic-import-node": "^2.0.0",
     "caniuse-lite": "^1.0.30000898",
     "debug": "^4.0.0",
+    "duplitect": "^1.0.3",
     "enhanced-resolve": "^4.0.0",
     "eprom": "^1.0.0",
     "file-loader": "^3.0.0",
@@ -48,5 +49,8 @@
   },
   "engines": {
     "node": ">8.6.0"
+  },
+  "scripts": {
+    "postinstall": "duplitect @untool/webpack"
   }
 }

--- a/packages/yargs/package.json
+++ b/packages/yargs/package.json
@@ -20,11 +20,15 @@
   "homepage": "https://github.com/untool/untool#readme",
   "dependencies": {
     "@untool/core": "^1.1.0",
+    "duplitect": "^1.0.3",
     "mixinable": "^4.0.0",
     "pretty-ms": "^4.0.0",
     "yargs": "^13.0.0"
   },
   "engines": {
     "node": ">8.6.0"
+  },
+  "scripts": {
+    "postinstall": "duplitect @untool/yargs"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplitect@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/duplitect/-/duplitect-1.0.3.tgz#d60be3907a549a230d2f04c4c4ea87640efb5a78"
+  integrity sha512-/sYPfcaufqwOIiF7SanmHZxWMwZMUdsOvlZsr6a8Xm4M9usgzUgqAdr9mSceDjIukhfbEoR8Qo2YzKb82xpjBQ==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
~Since duplicate detection takes quite a lot of time, we will have to decide whether to add it to all presets (as would be technically appropriate) or only to the main `untool` (and `hops`) packages.~

I found [a way](https://github.com/untool/duplitect/blob/9c0808d8e94465e4841d612aaa23f2952a126c85/index.js#L27-L66) to reduce detection time down to a fraction of a second. Thus, I was able to add `duplitect` to all packages. Now we can make sure not `untool` package can be installed more than once into any given project.