### PR TITLE
feat(react): allow to instruct babel plugin to use require.resolve

### DIFF
--- a/packages/react/lib/babel.js
+++ b/packages/react/lib/babel.js
@@ -55,7 +55,9 @@ module.exports = ({ types: t }) => ({
               t.callExpression(
                 t.memberExpression(
                   t.identifier('require'),
-                  t.identifier('resolveWeak')
+                  t.identifier(
+                    this.opts.resolveAbsolutePaths ? 'resolve' : 'resolveWeak'
+                  )
                 ),
                 [t.stringLiteral(importedComponent)]
               )


### PR DESCRIPTION
In compiled tests we want to use the `importComponent` feature but we need to set `this.state.Component` synchronously. For this we can provide a mock of `importComponent` in Hops but we need the absolute path to the requested component.

This commit adds an option to the babel plugin to allow to switch `require.resolveWeak` to `require.resolve` which can be used in babel-jest test setups.