### PR TITLE
fix(react): use `require` instead of `import`

### DIFF
--- a/packages/react/lib/babel.js
+++ b/packages/react/lib/babel.js
@@ -39,31 +39,33 @@ module.exports = ({ types: t }) => ({
           importedComponent = argument.get('body.arguments.0').node.value;
         }
 
-        argument.replaceWith(
-          t.objectExpression([
-            t.objectProperty(
-              t.identifier('load'),
-              t.arrowFunctionExpression(
-                [],
-                t.callExpression(t.identifier('import'), [
-                  t.stringLiteral(importedComponent),
-                ])
-              )
-            ),
-            t.objectProperty(
+        const loadModuleFn = this.opts.resolveAbsolutePaths
+          ? 'require'
+          : 'import';
+        const load = t.objectProperty(
+          t.identifier('load'),
+          t.arrowFunctionExpression(
+            [],
+            t.callExpression(t.identifier(loadModuleFn), [
+              t.stringLiteral(importedComponent),
+            ])
+          )
+        );
+        const moduleId = this.opts.resolveAbsolutePaths
+          ? null
+          : t.objectProperty(
               t.identifier('moduleId'),
               t.callExpression(
                 t.memberExpression(
                   t.identifier('require'),
-                  t.identifier(
-                    this.opts.resolveAbsolutePaths ? 'resolve' : 'resolveWeak'
-                  )
+                  t.identifier('resolveWeak')
                 ),
                 [t.stringLiteral(importedComponent)]
               )
-            ),
-          ])
-        );
+            );
+        const properties = [load, moduleId].filter(Boolean);
+
+        argument.replaceWith(t.objectExpression(properties));
       });
     },
   },


### PR DESCRIPTION
…when the `resolveAbsolutePaths`-option is set to `true`.

Also do not include the `moduleId`-property in that case since it is only needed
for the module-ID-related resolving scenario in the context of Webpack.

This fix enables downstream projects to use the result of the Babel plugin
with Node v8. Otherwise this would lead to the syntax error `Unexpected token import`.