### PR TITLE
refactor(react): remove `resolveAbsolutePaths` option

### DIFF
--- a/packages/react/lib/babel.js
+++ b/packages/react/lib/babel.js
@@ -55,9 +55,7 @@ module.exports = ({ types: t }) => ({
               t.callExpression(
                 t.memberExpression(
                   t.identifier('require'),
-                  t.identifier(
-                    this.opts.resolveAbsolutePaths ? 'resolve' : 'resolveWeak'
-                  )
+                  t.identifier('resolveWeak')
                 ),
                 [t.stringLiteral(importedComponent)]
               )


### PR DESCRIPTION
Because it opened the plugin for uses cases it is not meant to be used for.