### PR TITLE
WIP/RFC: Introduce Doctor/Diagnosis Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
         [
           "untool",
           "core",
+          "doctor",
           "express",
           "react",
           "webpack",

--- a/packages/core/lib/config.js
+++ b/packages/core/lib/config.js
@@ -51,11 +51,12 @@ exports.getConfig = ({ untoolNamespace = 'untool', ...overrides } = {}) => {
   const settings = loadConfig(untoolNamespace, pkgData, rootDir);
 
   const raw = merge(defaults, settings, overrides);
-  const { mixins, mixinTypes, configSchema, ...clean } = raw;
+  const { presets, mixins, mixinTypes, configSchema, ...clean } = raw;
   const processed = environmentalize(placeholdify(clean));
 
   const config = {
     ...processed,
+    _presets: presets,
     _mixins: resolveMixins(rootDir, mixinTypes, mixins),
     _warnings: validate(processed, configSchema),
     _workspace: lockFile ? dirname(lockFile) : rootDir,

--- a/packages/core/lib/loader.js
+++ b/packages/core/lib/loader.js
@@ -77,7 +77,5 @@ exports.loadConfig = (namespace, pkgData, rootDir) => {
   const settings = loader.loadSettings(rootDir);
   const presets = loader.loadPresets(rootDir, settings.presets);
 
-  // eslint-disable-next-line no-unused-vars
-  const { presets: _, ...config } = merge(presets, settings);
-  return config;
+  return merge(presets, settings);
 };

--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -39,6 +39,9 @@ exports.merge = (...args) =>
       if ('mixins' === key) {
         return [...objValue, ...srcValue];
       }
+      if ('presets' === key) {
+        return [...srcValue, ...objValue];
+      }
       return srcValue;
     }
   });

--- a/packages/dist/preset.js
+++ b/packages/dist/preset.js
@@ -6,5 +6,6 @@ module.exports = {
     '@untool/express',
     '@untool/webpack',
     '@untool/react',
+    '@untool/doctor',
   ],
 };

--- a/packages/doctor/README.md
+++ b/packages/doctor/README.md
@@ -1,0 +1,3 @@
+# `@untool/doctor`
+
+[![travis](https://img.shields.io/travis/untool/untool/master.svg)](https://travis-ci.org/untool/untool)&nbsp;[![npm](https://img.shields.io/npm/v/@untool%2Fdoctor.svg)](https://www.npmjs.com/package/@untool%2Fdoctor)

--- a/packages/doctor/mixins/mixin.core.js
+++ b/packages/doctor/mixins/mixin.core.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const detectDuplicates = require('duplitect');
+const {
+  async: { parallel },
+} = require('mixinable');
+
+const {
+  Mixin,
+  internal: { validate, invariant },
+} = require('@untool/core');
+
+const parallelWithFlatReturn = (...args) => {
+  return parallel(...args).then((results) => [].concat(...results));
+};
+
+class DoctorMixin extends Mixin {
+  bootstrap() {
+    if (typeof this.getLogger === 'function') {
+      const { config } = this;
+      const logger = this.getLogger();
+      return this.runChecks().then((warnings) =>
+        [...config._warnings, ...warnings].forEach((warning) =>
+          logger.warn(warning)
+        )
+      );
+    }
+  }
+  runChecks() {
+    const { _workspace } = this.config;
+    return detectDuplicates(_workspace, '@untool/*').map(
+      (duplicate) => `package '${duplicate}' should be installed just once`
+    );
+  }
+}
+
+DoctorMixin.strategies = {
+  runChecks: validate(
+    parallelWithFlatReturn,
+    ({ length }) => {
+      invariant(length === 0, 'runChecks(): Received unexpected argument(s)');
+    },
+    (result) => {
+      invariant(Array.isArray(result), 'runChecks(): Did not return array');
+    }
+  ),
+};
+
+module.exports = DoctorMixin;

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@untool/doctor",
+  "version": "1.3.1",
+  "description": "untool doctor mixin",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/untool/untool.git"
+  },
+  "author": "dmbch <daniel@dmbch.net>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/untool/untool/issues"
+  },
+  "homepage": "https://github.com/untool/untool#readme",
+  "dependencies": {
+    "@untool/core": "^1.3.1",
+    "duplitect": "^2.0.0",
+    "mixinable": "^4.0.0"
+  },
+  "engines": {
+    "node": ">8.6.0"
+  }
+}

--- a/packages/doctor/preset.js
+++ b/packages/doctor/preset.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { join } = require('path');
+
+module.exports = {
+  mixins: [join(__dirname, 'mixins')],
+};

--- a/packages/yargs/mixins/log/mixin.core.js
+++ b/packages/yargs/mixins/log/mixin.core.js
@@ -45,9 +45,6 @@ class LogMixin extends Mixin {
   handleError(error) {
     this.getLogger().error(error);
   }
-  inspectWarnings(warnings) {
-    warnings.forEach((warning) => this.getLogger().warn(warning));
-  }
 }
 
 LogMixin.strategies = {

--- a/packages/yargs/package.json
+++ b/packages/yargs/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@untool/core": "^1.3.1",
     "chalk": "^2.4.2",
-    "duplitect": "^2.0.0",
     "mixinable": "^4.0.0",
     "yargs": "^13.0.0"
   },


### PR DESCRIPTION
I would like to explore and discuss adding a central package that consolidates all cross-cutting checks (think [`duplitect`](https://github.com/untool/duplitect), #297, config validation etc.) currently scattered across our different packages. CRA appears to follow a similar approach in its [`verify*` scripts](https://github.com/facebook/create-react-app/tree/master/packages/react-scripts/scripts/utils).

Besides that, I would like it to add a `diagnose` command similar to [`brew doctor`](https://docs.brew.sh/Manpage#doctor-options) that runs the aforementioned checks and gathers additional information on the application it is running in (installed presets, env variables, config, file system permissions, package and engine versions etc.).

To be honest, I am still considering if the `untool` package itself might be the best place for all of the above: it already 'knows' about all other packages anyway and is our official entry point. It could, of course, also expose the `doctor` mixin for when it is not being used as a preset.

Another alternative might be to put that doctor stuff back into `@untool/yargs`, but keep up around as a separate mixin.

In any case certain checks such as the one necessitated by #297 will have to be performed in the module context of the respective preset. On the other hand, elaborate mitigation hints ought to be centralized imo to prevent duplication.