### PR TITLE
fix(react): switch to supported react router imports

### DIFF
--- a/packages/react/lib/runtime.js
+++ b/packages/react/lib/runtime.js
@@ -2,7 +2,7 @@
 /* global __webpack_modules__, __webpack_require__ */
 
 const { isValidElement, createElement, Component } = require('react');
-const { default: withRouter } = require('react-router-dom/es/withRouter');
+const { withRouter } = require('react-router-dom');
 const isPlainObject = require('is-plain-object');
 const PropTypes = require('prop-types');
 

--- a/packages/react/mixins/mixin.browser.js
+++ b/packages/react/mixins/mixin.browser.js
@@ -4,7 +4,7 @@
 
 const { createElement, isValidElement } = require('react');
 const { unmountComponentAtNode, hydrate, render } = require('react-dom');
-const { default: BrowserRouter } = require('react-router-dom/es/BrowserRouter');
+const { BrowserRouter } = require('react-router-dom');
 
 const isPlainObject = require('is-plain-object');
 

--- a/packages/react/mixins/mixin.server.js
+++ b/packages/react/mixins/mixin.server.js
@@ -4,7 +4,7 @@ const { parse } = require('url');
 
 const { createElement, isValidElement } = require('react');
 const { renderToString } = require('react-dom/server');
-const { default: StaticRouter } = require('react-router-dom/es/StaticRouter');
+const { StaticRouter } = require('react-router-dom');
 const {
   Helmet: { renderStatic },
 } = require('react-helmet');

--- a/tests/fixtures/untest/index.js
+++ b/tests/fixtures/untest/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { Fragment } from 'react';
-import { Switch, Route, Link } from 'react-router-dom/es';
+import { Switch, Route, Link } from 'react-router-dom';
 
 import { Miss, render, importComponent } from 'untool';
 


### PR DESCRIPTION
Our fixture breaks with the newest version of React Router (v4.4.0) due to this statement:

https://github.com/untool/untool/blob/1621634bdac34f377af23d11c67c0fbb11d04f31/tests/fixtures/untest/index.js#L3

The relevant change was apparently introduced around React Router [v4.4.0-beta2](https://github.com/ReactTraining/react-router/releases/tag/v4.4.0-beta.2). Additionally, warnings are emitted for our other deep imports from React Router, e.g.:

https://github.com/untool/untool/blob/1621634bdac34f377af23d11c67c0fbb11d04f31/packages/react/lib/runtime.js#L5

This PR addresses these issues