### PR TITLE
fix(info): make sure logger can be `util.inspect`ed

### DIFF
--- a/packages/info/lib/logger.js
+++ b/packages/info/lib/logger.js
@@ -60,6 +60,7 @@ class Logger {
 exports.createLogger = (...args) =>
   new Proxy(new Logger(...args), {
     get(logger, prop) {
+      if (typeof prop !== 'string') return logger[prop];
       return prop in logger
         ? typeof logger[prop] === 'function'
           ? logger[prop].bind(logger)


### PR DESCRIPTION
Currently, if started in debug mode, `untool` breaks due to our logger being inspected..:

```text
$ DEBUG=untool* yarn start
[...]
untest:info running 'start' in 'development' mode
untest:error TypeError: Cannot convert a Symbol value to a string
    at Logger._ (./packages/info/lib/logger.js:53:40)
    at formatValue (internal/util/inspect.js:522:31)
    at formatProperty (internal/util/inspect.js:1248:11)
    at formatRaw (internal/util/inspect.js:771:9)
    at formatValue (internal/util/inspect.js:540:10)
    at formatProperty (internal/util/inspect.js:1248:11)
    at formatArray (internal/util/inspect.js:1076:17)
    at formatRaw (internal/util/inspect.js:768:14)
    at formatValue (internal/util/inspect.js:540:10)
    at formatProperty (internal/util/inspect.js:1248:11)
```

With this PR, we make sure `Logger` instances can be inspected, thus preventing this kind of crashes.