### PR TITLE
fix(core): take last Mixin constructor arg as options object

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -8,7 +8,7 @@ const { getConfig, getMixins } = require('./lib/config');
 
 exports.Mixin = class Mixin {
   constructor(config, ...args) {
-    const options = args.slice(-1);
+    const options = args[args.length - 1];
     this.config = config;
     this.options = isPlainObject(options) ? options : {};
   }


### PR DESCRIPTION
`args.slice(-1)` would return an array containing the last element of
the args rest, but an array fails the `isPlainObject()` test, therefore
`this.options` would always be set to an empty object, even if
`core.initialize(overrides, { production: true })` was called with an
options object as its second argument.