### PR TITLE
fix(webpack): keep config loader small by reducing dependencies

### DIFF
--- a/packages/webpack/lib/utils/loader.js
+++ b/packages/webpack/lib/utils/loader.js
@@ -36,7 +36,7 @@ const configs = {};
 exports.getConfig = (overrides = {}) => {
   const key = Object.keys(overrides).length ? JSON.stringify(overrides) : '_';
   if (!configs[key]) {
-    const { internal: utils } = require('@untool/core');
+    const utils = require('@untool/core/lib/utils');
     const { environmentalize, placeholdify, merge } = utils;
     const raw = merge(${getConfig(type, config)}, overrides);
     configs[key] = environmentalize(placeholdify(raw));


### PR DESCRIPTION
With a recent change in untool we now can not generate loaders for
environments other than `browser` or `server`, because we load `utils`
from the `@untool/core` main file which already loads `./lib/config` and
therefore the `browser` config loader will always pass in all browser
mixins.

This commit partially reverts that change by importing the config utils
from `@untool/core/lib/utils` instead.
This is helpful for other compilers, for example the service-worker
compiler in Hops, to allow the service worker bundle to be very small
and not include React and other runtime dependencies.

Ref: https://github.com/untool/untool/commit/4b6352f239a04b223501381e4e9364e4dadb5607