### PR TITLE
refactor(webpack): move arg handling to appropriate hook

### DIFF
--- a/packages/webpack/mixins/stats/mixin.core.js
+++ b/packages/webpack/mixins/stats/mixin.core.js
@@ -19,6 +19,7 @@ class WebpackStatsMixin extends Mixin {
   constructor(...args) {
     super(...args);
     this.statsPromise = new EnhancedPromise();
+    this.handleArguments(this.options);
   }
   getBuildStats() {
     return Promise.resolve(this.statsPromise);
@@ -29,9 +30,7 @@ class WebpackStatsMixin extends Mixin {
       const { StatsPlugin } = require('../../lib/plugins/stats');
       plugins.unshift(new StatsPlugin(this.statsPromise));
     }
-    const isBuild =
-      this.options._.includes('build') || process.env.NODE_ENV === 'production';
-    if (target === 'node' && isBuild) {
+    if (target === 'node' && this.writeStats) {
       const { StatsFilePlugin } = require('../../lib/plugins/stats');
       plugins.unshift(new StatsFilePlugin(this.statsPromise, this.config));
     }
@@ -49,6 +48,11 @@ class WebpackStatsMixin extends Mixin {
   }
   handleArguments(argv) {
     this.options = { ...this.options, ...argv };
+    const { _: commands = [] } = this.options;
+    const isProduction = process.env.NODE_ENV === 'production';
+    this.writeStats =
+      commands.includes('build') ||
+      (commands.includes('start') && isProduction);
   }
 }
 


### PR DESCRIPTION
This is an alternate take on #357 - it attempts to solve the underlying issue without having to extend our API in somewhat unpleasant ways. I have come to think that it is indeed fine for this mixin to evaluate CLI args (and commands) its sibling mixins own/define and to react accordingly. I only prefer it doing to in the appropriate hook.

The implementation I am proposing ought to also be in line with #355, specifically with https://github.com/untool/untool/pull/355/commits/c704683854260dc8fcc2303e134bfe6e82f9ff7f.

Closes #357