### PR TITLE
fix(react): use is-plain-obj instead of is-plain-object

### DIFF
--- a/packages/react/mixins/mixin.server.js
+++ b/packages/react/mixins/mixin.server.js
@@ -5,7 +5,7 @@ const { parse } = require('url');
 const { createElement, isValidElement } = require('react');
 const { StaticRouter } = require('react-router-dom');
 
-const isPlainObject = require('is-plain-object');
+const isPlainObject = require('is-plain-obj');
 
 const {
   override: overrideSync,


### PR DESCRIPTION
Recently `is-plain-object` has been replaced by `is-plain-obj` in untool
unfortunately one call site was missing and therefore still tried to
load `is-plain-object`.
This PR changes that call site to require `is-plain-obj`.

Ref: https://github.com/untool/untool/commit/a96af55f89437959a879d903eb356bee625bd2f5