### PR TITLE
fix(core): arrays in config should override previous value

### DIFF
--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -35,10 +35,13 @@ exports.validate = (strategy, checkArgs = () => {}, checkResult = () => {}) =>
 
 exports.merge = (...args) =>
   mergeWith({}, ...args, (objValue, srcValue, key) => {
-    if (Array.isArray(objValue) && 'mixins' === key) {
-      return [...objValue, ...srcValue].filter(
-        (curr, index, self) => self.indexOf(curr) === index
-      );
+    if (Array.isArray(objValue)) {
+      if ('mixins' === key) {
+        return [...objValue, ...srcValue].filter(
+          (curr, index, self) => self.indexOf(curr) === index
+        );
+      }
+      return srcValue;
     }
   });
 


### PR DESCRIPTION
In #428 we tried to change the merging behaviour for mixins but also change the behaviour for other arrays. The result was that arrays in the config did not override the previous value.

This PR reverts the other change so that the result is:
```diff
-        return [...objValue, ...srcValue];
+        return [...objValue, ...srcValue].filter(
+          (curr, index, self) => self.indexOf(curr) === index
+        );
```