### PR TITLE
fix: add missing dependencies

### DIFF
--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -20,6 +20,7 @@
     "chalk": "^2.4.2",
     "duplitect": "^2.0.1",
     "enhanced-resolve": "^4.1.0",
+    "escape-string-regexp": "^2.0.0",
     "mixinable": "^4.0.0"
   },
   "engines": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -28,6 +28,7 @@
     "chalk": "^2.4.2",
     "core-js": "^2.6.9",
     "debug": "^4.0.0",
+    "directory-index": "^0.1.0",
     "duplitect": "^2.0.1",
     "enhanced-resolve": "^4.0.0",
     "eprom": "^1.0.0",


### PR DESCRIPTION
We use these packages here:
https://github.com/untool/untool/blob/1c7a73909ff08d9e91f0a90618bf65b0aaaafc78/packages/info/lib/logger.js#L7

And here:
https://github.com/untool/untool/blob/1c7a73909ff08d9e91f0a90618bf65b0aaaafc78/packages/webpack/lib/plugins/render.js#L3