### PR TITLE
chore: set-up GH action to automatically rebase next branch

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Rebase next against master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/untool/untool.git
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          ./scripts/rebase.sh master next

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -ex
+
+base_brach=${1:-master}
+head_branch=${2:-next}
+
+git fetch origin "$base_brach"
+git fetch origin "$head_branch"
+git checkout -b "$head_branch" "origin/$head_branch"
+
+is_rebasing=1
+
+exitcode=0 && git rebase "origin/$base_brach" || exitcode=$?
+if [[ $exitcode -eq 0 ]]; then is_rebasing=0; fi
+
+while [[ $is_rebasing == 1 ]]; do
+  conflicting_files="$(git diff --name-only --diff-filter=U)"
+  fixable_files="$(git diff --name-only --diff-filter=U yarn.lock tests/snapshots)"
+  if [[ "$conflicting_files" == "$fixable_files" ]]; then
+    yarn install
+    yarn test -u
+    git add yarn.lock tests/snapshots
+    exitcode=0 && git rebase --continue || exitcode=$?
+    if [[ $exitcode -eq 0 ]]; then
+      is_rebasing=0
+      break
+    fi
+  else
+    break
+  fi
+done
+
+if [[ $is_rebasing -eq 0 ]]; then
+  git push origin "$head_branch" --force-with-lease
+else
+  exit $exitcode
+fi


### PR DESCRIPTION
This action will run on every push to the master branch and rebase the
next branch against master.
If the rebase fails it will check if it is fixable (ie. only conflicts
in "yarn.lock" and/or "tests/snapshots/" and then execute
"yarn install" and "yarn test -u" to fix those conflicts and continue
to rebase.