### PR TITLE
refactor(webpack): escape forward slashes in regular expressions

### DIFF
--- a/packages/webpack/lib/configs/build.js
+++ b/packages/webpack/lib/configs/build.js
@@ -21,7 +21,8 @@ module.exports = function getConfig(config, name) {
 
   const jsLoaderConfig = {
     test: [/\.m?js$/],
-    exclude: [/node_modules[/\\]core-js/],
+    // eslint-disable-next-line no-useless-escape
+    exclude: [/node_modules[\/\\]core-js/],
     loader: require.resolve('babel-loader'),
     options: {
       babelrc: false,

--- a/packages/webpack/lib/configs/develop.js
+++ b/packages/webpack/lib/configs/develop.js
@@ -17,7 +17,8 @@ module.exports = function getConfig(config, name) {
 
   const jsLoaderConfig = {
     test: [/\.m?js$/],
-    exclude: [/node_modules[/\\]core-js/],
+    // eslint-disable-next-line no-useless-escape
+    exclude: [/node_modules[\/\\]core-js/],
     loader: require.resolve('babel-loader'),
     options: {
       babelrc: false,

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -20,7 +20,8 @@ module.exports = function getConfig(config, name) {
 
   const jsLoaderConfig = {
     test: [/\.m?js$/],
-    exclude: [/node_modules[/\\]core-js/],
+    // eslint-disable-next-line no-useless-escape
+    exclude: [/node_modules[\/\\]core-js/],
     loader: require.resolve('babel-loader'),
     options: {
       babelrc: false,


### PR DESCRIPTION
Apparently v8 changed how regular expressions are serialized (v8 got updated between Node.js v12.10.0 and v12.11.0), which causes our snapshot tests to fail.

![regex](https://user-images.githubusercontent.com/249542/65689555-95281580-e06d-11e9-9731-5602408d5b9a.png)

This change escapes the forward slash in the character group, which isn't exactly necessary (which is also why eslint complaints) but it works across all versions.