### PR TITLE
test: add core initialize test cases

### DIFF
--- a/packages/core/__tests__/fixtures/a-mixin.js
+++ b/packages/core/__tests__/fixtures/a-mixin.js
@@ -1,0 +1,34 @@
+const { callable, override, parallel, pipe, compose } = require('mixinable');
+const { Mixin } = require('../..');
+
+class AMixin extends Mixin {
+  callMe() {
+    return this.operation();
+  }
+
+  overridden() {
+    return 'from a-mixin';
+  }
+
+  parallel() {
+    return 'from a-mixin';
+  }
+
+  pipe(input) {
+    return `${input} Hello`.trim();
+  }
+
+  compose(input) {
+    return { 'a-mixin': input };
+  }
+}
+
+AMixin.strategies = {
+  callMe: callable,
+  overridden: override,
+  parallel,
+  pipe,
+  compose,
+};
+
+module.exports = AMixin;

--- a/packages/core/__tests__/fixtures/a-mixin.js
+++ b/packages/core/__tests__/fixtures/a-mixin.js
@@ -2,11 +2,11 @@ const { callable, override, parallel, pipe, compose } = require('mixinable');
 const { Mixin } = require('../..');
 
 class AMixin extends Mixin {
-  callMe() {
-    return this.operation();
+  callFirst() {
+    return this.callSecond();
   }
 
-  overridden() {
+  override() {
     return 'from a-mixin';
   }
 
@@ -24,8 +24,8 @@ class AMixin extends Mixin {
 }
 
 AMixin.strategies = {
-  callMe: callable,
-  overridden: override,
+  callFirst: callable,
+  override,
   parallel,
   pipe,
   compose,

--- a/packages/core/__tests__/fixtures/another-mixin.js
+++ b/packages/core/__tests__/fixtures/another-mixin.js
@@ -2,11 +2,11 @@ const { callable, override, parallel, pipe, compose } = require('mixinable');
 const { Mixin } = require('../..');
 
 class AnotherMixin extends Mixin {
-  operation() {
-    return 'execute operation';
+  callSecond() {
+    return 'execute callSecond';
   }
 
-  overridden() {
+  override() {
     return 'from another-mixin';
   }
 
@@ -24,8 +24,8 @@ class AnotherMixin extends Mixin {
 }
 
 AnotherMixin.strategies = {
-  operation: callable,
-  overridden: override,
+  callSecond: callable,
+  override,
   parallel,
   pipe,
   compose,

--- a/packages/core/__tests__/fixtures/another-mixin.js
+++ b/packages/core/__tests__/fixtures/another-mixin.js
@@ -1,0 +1,34 @@
+const { callable, override, parallel, pipe, compose } = require('mixinable');
+const { Mixin } = require('../..');
+
+class AnotherMixin extends Mixin {
+  operation() {
+    return 'execute operation';
+  }
+
+  overridden() {
+    return 'from another-mixin';
+  }
+
+  parallel() {
+    return 'from another-mixin';
+  }
+
+  pipe(input) {
+    return `${input} World`.trim();
+  }
+
+  compose(input) {
+    return { 'another-mixin': input };
+  }
+}
+
+AnotherMixin.strategies = {
+  operation: callable,
+  overridden: override,
+  parallel,
+  pipe,
+  compose,
+};
+
+module.exports = AnotherMixin;

--- a/packages/core/__tests__/fixtures/test-mixin.js
+++ b/packages/core/__tests__/fixtures/test-mixin.js
@@ -1,0 +1,12 @@
+const { Mixin } = require('../..');
+
+class TestMixin extends Mixin {
+  constructor(...args) {
+    super(...args);
+    TestMixin.mixinCreated = true;
+  }
+}
+
+TestMixin.mixinCreated = false;
+
+module.exports = TestMixin;

--- a/packages/core/__tests__/index.test.js
+++ b/packages/core/__tests__/index.test.js
@@ -16,7 +16,7 @@ test('Should connect mixins through strategies', (t) => {
     ],
   });
 
-  t.is(instance.callMe(), 'execute operation');
+  t.is(instance.callFirst(), 'execute callSecond');
 });
 
 test('Should support override stategie by order of mixins', (t) => {
@@ -33,8 +33,8 @@ test('Should support override stategie by order of mixins', (t) => {
     ],
   });
 
-  t.is(instance1.overridden(), 'from another-mixin');
-  t.is(instance2.overridden(), 'from a-mixin');
+  t.is(instance1.override(), 'from another-mixin');
+  t.is(instance2.override(), 'from a-mixin');
 });
 
 test('Should support parallel stategie', (t) => {

--- a/packages/core/__tests__/index.test.js
+++ b/packages/core/__tests__/index.test.js
@@ -1,0 +1,73 @@
+const { join } = require('path');
+const test = require('ava');
+const { initialize } = require('..');
+
+test('Should create a explicitly given mixin', (t) => {
+  initialize({ mixins: [join(__dirname, 'fixtures', 'test-mixin')] });
+
+  t.truthy(require('./fixtures/test-mixin').mixinCreated);
+});
+
+test('Should connect mixins through strategies', (t) => {
+  const instance = initialize({
+    mixins: [
+      join(__dirname, 'fixtures', 'a-mixin'),
+      join(__dirname, 'fixtures', 'another-mixin'),
+    ],
+  });
+
+  t.is(instance.callMe(), 'execute operation');
+});
+
+test('Should support override stategie by order of mixins', (t) => {
+  const instance1 = initialize({
+    mixins: [
+      join(__dirname, 'fixtures', 'a-mixin'),
+      join(__dirname, 'fixtures', 'another-mixin'),
+    ],
+  });
+  const instance2 = initialize({
+    mixins: [
+      join(__dirname, 'fixtures', 'another-mixin'),
+      join(__dirname, 'fixtures', 'a-mixin'),
+    ],
+  });
+
+  t.is(instance1.overridden(), 'from another-mixin');
+  t.is(instance2.overridden(), 'from a-mixin');
+});
+
+test('Should support parallel stategie', (t) => {
+  const instance = initialize({
+    mixins: [
+      join(__dirname, 'fixtures', 'a-mixin'),
+      join(__dirname, 'fixtures', 'another-mixin'),
+    ],
+  });
+
+  t.deepEqual(instance.parallel(), ['from a-mixin', 'from another-mixin']);
+});
+
+test('Should support pipe stategie', (t) => {
+  const instance = initialize({
+    mixins: [
+      join(__dirname, 'fixtures', 'a-mixin'),
+      join(__dirname, 'fixtures', 'another-mixin'),
+    ],
+  });
+
+  t.is(instance.pipe(''), 'Hello World');
+});
+
+test('Should support compose stategie', (t) => {
+  const instance = initialize({
+    mixins: [
+      join(__dirname, 'fixtures', 'a-mixin'),
+      join(__dirname, 'fixtures', 'another-mixin'),
+    ],
+  });
+
+  t.deepEqual(instance.compose({ input: 0 }), {
+    'a-mixin': { 'another-mixin': { input: 0 } },
+  });
+});


### PR DESCRIPTION
This should check the different mixin options from untool initialize.