### PR TITLE
chore: add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'live'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'chore'


### PR DESCRIPTION
…mainly for preventing it from using the invalid "deps"-scope in its
commit messages. 🤷‍♂️