### PR TITLE
fix(react): set data-mounted attribute after hydration

### DIFF
--- a/packages/react/mixins/mixin.browser.js
+++ b/packages/react/mixins/mixin.browser.js
@@ -37,20 +37,21 @@ class ReactMixin extends Mixin {
     );
   }
   render() {
-    const mountpoint = document.querySelector('[data-mountpoint]');
-    const isMounted = mountpoint.hasAttribute('data-mounted');
-    if (isMounted) {
-      unmountComponentAtNode(mountpoint);
-    } else {
-      mountpoint.setAttribute('data-mounted', '');
-    }
     Promise.resolve()
       .then(() => this.bootstrap())
       .then(() => this.enhanceElement(this.element))
       .then((element) =>
-        this.fetchData({}, element).then(() =>
-          (isMounted ? render : hydrate)(element, mountpoint)
-        )
+        this.fetchData({}, element).then(() => {
+          const mountpoint = document.querySelector('[data-mountpoint]');
+          const isMounted = mountpoint.hasAttribute('data-mounted');
+          if (isMounted) {
+            unmountComponentAtNode(mountpoint);
+            render(element, mountpoint);
+          } else {
+            hydrate(element, mountpoint);
+            mountpoint.setAttribute('data-mounted', '');
+          }
+        })
       );
   }
 }


### PR DESCRIPTION
We should wait with unmounting and setting of the `data-mounted` attribute until after the `fetchData` call.
This fix would allow us to wait in our browser tests for the `data-mounted` attribute in order to make sure to have all event handlers bound.

I wonder why this was never an issue before.